### PR TITLE
Automation of JavaDoc with javadoc.yml file inside github workflows

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -1,0 +1,20 @@
+name: Deploy Javadoc
+
+on:
+  push:
+    branches:
+      - dev
+      
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy JavaDoc 🚀
+        uses: MathieuSoysal/Javadoc-publisher.yml@v2.3.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          javadoc-branch: javadoc
+          java-version: 17
+          target-folder: javadoc 
+          project: gradle


### PR DESCRIPTION
This should allow for all code with correct comments format to automatically get documented by javadocs when pushed